### PR TITLE
Use sketch name for compilation file names

### DIFF
--- a/electron.js
+++ b/electron.js
@@ -19,10 +19,7 @@ var BOARDS = require('./boards').loadBoards();
 var LIBS   = require('./libraries').loadLibraries();
 //standard options
 var OPTIONS = {
-    userlibs: settings.userlibs,
-    root: settings.root,
-    hardware: settings.root + '/hardware',
-    avrbase: settings.root + '/hardware/tools/avr/bin'
+    userlibs: settings.userlibs
 }
 
 console.log('settings',settings);


### PR DESCRIPTION
I noticed the hardcoding of "Blink" in the compilation sequence. I'm guessing that was just a placeholder. If so, this pull request changes that to use the sketch name instead. Feel free to reject this if you had other intentions for the naming.
