### PR TITLE
Issue #34: Detect board model on serial port

### DIFF
--- a/electron.js
+++ b/electron.js
@@ -43,6 +43,18 @@ app.use(express.static(__dirname+'/public'));
 
 app.get('/ports',function(req,res) {
     sp.list(function(err,list) {
+
+        // format the data (workaround serialport issue on Win (&*nix?))
+        list.forEach(function(port) {
+            if(port.pnpId){
+                var data = /^USB\\VID_([a-fA-F0-9]{4})\&PID_([a-fA-F0-9]{4})/.exec(port.pnpId);
+                if(data){
+                    port.vendorId = port.vendorId || '0x'+data[1];
+                    port.productId = port.productId || '0x'+data[2];
+                }
+            }
+        });
+
         res.send(JSON.stringify(list));
         res.end();
     });

--- a/public/index.html
+++ b/public/index.html
@@ -264,6 +264,7 @@ editor.getSession().setMode('ace/mode/c_cpp');
 editor.getSession().setUseWrapMode(true);
 
 var BOARDS = [];
+var PORTS = [];
 
 var STATE = {
     port:'',
@@ -274,6 +275,25 @@ var STATE = {
 function setPort(port) {
     STATE.port = port;
     $("#port-selector .data").text(port);
+
+    // attempt to determine which board is connected at this port
+    // find port in PORTS
+    var fullPort = PORTS.filter(function(portData){
+        return port === portData.comName;
+    })[0];
+
+    if(fullPort){
+        var boardMatched = BOARDS.filter(function(board, ind){
+            if(board && board.build && board.build.pid){
+                return board.build.pid === fullPort.productId && board.build.vid === fullPort.vendorId;
+            }
+        })[0];
+
+        if(boardMatched){
+            setBoard(boardMatched.id);
+        }
+    }
+
 }
 function setBoard(board) {
     STATE.board = board;
@@ -317,7 +337,8 @@ function loadSketch(name) {
 
 function fetchSerialports(cb) {
     $.get(HOSTNAME+"/ports",function(res) {
-        cb(JSON.parse(res));
+        PORTS = JSON.parse(res);
+        cb(PORTS);
     })
 }
 function populateSerialports(ports) {


### PR DESCRIPTION
(#34) uses a workaround for issue on Windows of not populating vendor and
product IDs
