### PR TITLE
support spaces in file names during compile

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -463,13 +463,13 @@ function compileCPP(options, outdir, includepaths, cfile,debug, cb) {
     ];
 
     includepaths.forEach(function(path){
-        cmd.push("-I"+path);
+        cmd.push("-I"+'"'+path+'"');
     })
 
-    cmd.push(cfile); //add the actual c++ file
+    cmd.push(' "'+cfile+'"'); //add the actual c++ file
     cmd.push('-o'); //output object file
     var filename = cfile.substring(cfile.lastIndexOf('/')+1);
-    cmd.push(outdir+'/'+filename+'.o');
+    cmd.push('"'+outdir+'/'+filename+'.o"');
 
     exec(cmd,cb, debug);
 }
@@ -492,12 +492,12 @@ function compileC(options, outdir, includepaths, cfile, debug, cb) {
         '-DUSB_PID='+options.device.pid, //??
     ];
     includepaths.forEach(function(path){
-        cmd.push("-I"+path);
+        cmd.push("-I"+'"'+path+'"');
     })
     cmd.push(cfile); //add the actual c file
     cmd.push('-o');
     var filename = cfile.substring(cfile.lastIndexOf('/')+1);
-    cmd.push(outdir+'/'+filename+'.o');
+    cmd.push('"'+outdir+'/'+filename+'.o"');
 
     exec(cmd, cb, debug);
 }


### PR DESCRIPTION
Hey Josh,

Under linux avr-g++ fails when passed a sketch with spaces in the name.

```
/home/sam/ElectronIDE/downloads/platforms/1.0.5/linux/hardware/tools/avr/bin/avr-g++ -c -g -Os -Wall -fno-exceptions -ffunction-sections -fdata-sections -mmcu=atmega328p -DF_CPU=16000000L -MMD -DARDUINO=105 -DUSB_VID=0x2341 -DUSB_PID=0x0043 -I/home/sam/ElectronIDE/downloads/platforms/1.0.5/linux/hardware/arduino/cores/arduino -I/home/sam/ElectronIDE/downloads/platforms/1.0.5/linux/hardware/arduino/variants/standard -I/home/sam/ownCloud/Electronics/sketchbook/Simple Onboard Blinker build/tmp/Simple Onboard Blinker.cpp -o build/out/Simple Onboard Blinker.cpp.o
avr-g++: Onboard: No such file or directory
avr-g++: Blinker: No such file or directory
avr-g++: build/tmp/Simple: No such file or directory
avr-g++: Onboard: No such file or directory
avr-g++: Blinker.cpp: No such file or directory
avr-g++: Onboard: No such file or directory
avr-g++: Blinker.cpp.o: No such file or directory
avr-g++: no input files
```

I had a shot at fixing this, i'm pretty new to Node though. Seems to work.

Cheers,
Sam.
